### PR TITLE
feat: add Qwen Code provider with Device Code Flow OAuth

### DIFF
--- a/app/dashboard/accounts/add-account-dialog.tsx
+++ b/app/dashboard/accounts/add-account-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -24,6 +24,7 @@ import {
   ArrowRight,
   Zap,
   Sparkles,
+  Terminal,
   Check,
   Copy,
 } from "lucide-react";
@@ -33,17 +34,39 @@ import {
   exchangeAntigravityOAuthCode,
   getIflowAuthUrl,
   getAntigravityAuthUrl,
+  initiateQwenCodeAuth,
+  pollQwenCodeAuth,
 } from "@/lib/actions/accounts";
 import { cn } from "@/lib/utils";
 
-type Provider = "iflow" | "antigravity" | null;
+type Provider = "iflow" | "antigravity" | "qwen_code" | null;
 
-const PROVIDERS = {
+interface OAuthRedirectConfig {
+  flowType: "oauth_redirect";
+  getAuthUrl: () => Promise<{ success: true; data: { authUrl: string } } | { success: false; error: string }>;
+  exchangeAction: (callbackUrl: string) => Promise<{ success: true; data: { email: string; isUpdate: boolean } } | { success: false; error: string }>;
+}
+
+interface DeviceCodeConfig {
+  flowType: "device_code";
+}
+
+interface ProviderConfig {
+  name: string;
+  icon: typeof Zap;
+  color: "blue" | "purple" | "orange";
+  description: string;
+}
+
+type ProviderFullConfig = ProviderConfig & (OAuthRedirectConfig | DeviceCodeConfig);
+
+const PROVIDERS: Record<Exclude<Provider, null>, ProviderFullConfig> = {
   iflow: {
     name: "iFlow",
     icon: Zap,
     color: "blue",
     description: "Access OpenAI compatible API",
+    flowType: "oauth_redirect",
     getAuthUrl: getIflowAuthUrl,
     exchangeAction: exchangeIflowOAuthCode,
   },
@@ -52,10 +75,24 @@ const PROVIDERS = {
     icon: Sparkles,
     color: "purple",
     description: "Access Gemini & Claude via Google OAuth",
+    flowType: "oauth_redirect",
     getAuthUrl: getAntigravityAuthUrl,
     exchangeAction: exchangeAntigravityOAuthCode,
   },
-} as const;
+  qwen_code: {
+    name: "Qwen Code",
+    icon: Terminal,
+    color: "orange",
+    description: "Access Qwen Coder models",
+    flowType: "device_code",
+  },
+};
+
+const COLOR_CLASSES: Record<ProviderConfig["color"], string> = {
+  blue: "text-blue-500",
+  purple: "text-purple-500",
+  orange: "text-orange-500",
+};
 
 export function AddAccountDialog() {
   const router = useRouter();
@@ -65,28 +102,68 @@ export function AddAccountDialog() {
   const [callbackUrl, setCallbackUrl] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState("");
+  
+  // OAuth redirect flow state
   const [authUrl, setAuthUrl] = useState("");
   const [isFetchingUrl, setIsFetchingUrl] = useState(false);
+  
+  // Device code flow state
+  const [deviceCodeInfo, setDeviceCodeInfo] = useState<{
+    deviceCode: string;
+    verificationUrl: string;
+    codeVerifier: string;
+  } | null>(null);
+  const [isPolling, setIsPolling] = useState(false);
+  const pollingRef = useRef<NodeJS.Timeout | null>(null);
 
-  // Fetch auth URL when entering step 2
+  const providerConfig = provider ? PROVIDERS[provider] : null;
+
+  // Cleanup polling on unmount or dialog close
   useEffect(() => {
-    if (step === 2 && provider) {
-      setIsFetchingUrl(true);
-      setAuthUrl("");
-      PROVIDERS[provider]
-        .getAuthUrl()
-        .then((result) => {
-          if (result.success) {
-            setAuthUrl(result.data.authUrl);
-          } else {
-            setError(result.error);
-          }
-        })
-        .finally(() => setIsFetchingUrl(false));
-    }
-  }, [step, provider]);
+    return () => {
+      if (pollingRef.current) {
+        clearInterval(pollingRef.current);
+        pollingRef.current = null;
+      }
+    };
+  }, []);
 
-  const resetForm = () => {
+  // Fetch auth URL or initiate device code when entering step 2
+  useEffect(() => {
+    if (step === 2 && provider && providerConfig) {
+      if (providerConfig.flowType === "oauth_redirect") {
+        setIsFetchingUrl(true);
+        setAuthUrl("");
+        providerConfig.getAuthUrl()
+          .then((result) => {
+            if (result.success) {
+              setAuthUrl(result.data.authUrl);
+            } else {
+              setError(result.error);
+            }
+          })
+          .finally(() => setIsFetchingUrl(false));
+      } else if (providerConfig.flowType === "device_code") {
+        setIsFetchingUrl(true);
+        setDeviceCodeInfo(null);
+        initiateQwenCodeAuth()
+          .then((result) => {
+            if (result.success) {
+              setDeviceCodeInfo({
+                deviceCode: result.data.deviceCode,
+                verificationUrl: result.data.verificationUrlComplete,
+                codeVerifier: result.data.codeVerifier,
+              });
+            } else {
+              setError(result.error);
+            }
+          })
+          .finally(() => setIsFetchingUrl(false));
+      }
+    }
+  }, [step, provider, providerConfig]);
+
+  const resetForm = useCallback(() => {
     setStep(1);
     setProvider(null);
     setCallbackUrl("");
@@ -94,10 +171,16 @@ export function AddAccountDialog() {
     setIsLoading(false);
     setAuthUrl("");
     setIsFetchingUrl(false);
-  };
+    setDeviceCodeInfo(null);
+    setIsPolling(false);
+    if (pollingRef.current) {
+      clearInterval(pollingRef.current);
+      pollingRef.current = null;
+    }
+  }, []);
 
   const handleOpenChange = (isOpen: boolean) => {
-    if (!isLoading) {
+    if (!isLoading && !isPolling) {
       setOpen(isOpen);
       if (!isOpen) {
         resetForm();
@@ -113,20 +196,17 @@ export function AddAccountDialog() {
   const handleStartOAuth = () => {
     if (!authUrl) return;
 
-    // Hitung posisi tengah layar
     const width = 600;
     const height = 700;
     const left = Math.round((window.screen.width - width) / 2);
     const top = Math.round((window.screen.height - height) / 2);
 
-    // Coba buka di new window (di tengah layar)
     const popup = window.open(
       authUrl,
       "oauth_popup",
       `width=${width},height=${height},left=${left},top=${top},scrollbars=yes,resizable=yes`
     );
 
-    // Fallback ke new tab jika popup diblock atau gagal
     if (!popup || popup.closed) {
       window.open(authUrl, "_blank");
     }
@@ -134,9 +214,112 @@ export function AddAccountDialog() {
     setStep(3);
   };
 
+  const handleStartDeviceCodeAuth = () => {
+    if (!deviceCodeInfo) return;
+
+    // Open in centered popup window (same as OAuth flow)
+    const width = 600;
+    const height = 700;
+    const left = Math.round((window.screen.width - width) / 2);
+    const top = Math.round((window.screen.height - height) / 2);
+
+    const popup = window.open(
+      deviceCodeInfo.verificationUrl,
+      "qwen_auth_popup",
+      `width=${width},height=${height},left=${left},top=${top},scrollbars=yes,resizable=yes`
+    );
+
+    // Fallback to new tab if popup blocked
+    if (!popup || popup.closed) {
+      window.open(deviceCodeInfo.verificationUrl, "_blank");
+      startPolling(null);
+    } else {
+      startPolling(popup);
+    }
+  };
+
+  const startPolling = useCallback((popup: Window | null) => {
+    if (!deviceCodeInfo || isPolling) return;
+
+    setIsPolling(true);
+    setError("");
+
+    const poll = async () => {
+      if (!deviceCodeInfo) return;
+
+      // Check if popup was closed by user
+      if (popup && popup.closed) {
+        setIsPolling(false);
+        setError("");
+        if (pollingRef.current) {
+          clearInterval(pollingRef.current);
+          pollingRef.current = null;
+        }
+        return;
+      }
+
+      try {
+        const result = await pollQwenCodeAuth(
+          deviceCodeInfo.deviceCode,
+          deviceCodeInfo.codeVerifier
+        );
+
+        if (!result.success) {
+          setError(result.error);
+          setIsPolling(false);
+          if (pollingRef.current) {
+            clearInterval(pollingRef.current);
+            pollingRef.current = null;
+          }
+          return;
+        }
+
+        if (result.data.status === "success") {
+          // Close popup if still open
+          if (popup && !popup.closed) {
+            popup.close();
+          }
+          toast.success(
+            result.data.isUpdate
+              ? "Qwen Code account updated successfully!"
+              : "Qwen Code account connected successfully!"
+          );
+          setOpen(false);
+          resetForm();
+          router.refresh();
+          return;
+        }
+
+        if (result.data.status === "error") {
+          setError(result.data.message);
+          setIsPolling(false);
+          if (pollingRef.current) {
+            clearInterval(pollingRef.current);
+            pollingRef.current = null;
+          }
+          return;
+        }
+
+        // status === "pending" - continue polling
+      } catch (err) {
+        console.error("Polling error:", err);
+      }
+    };
+
+    // Initial poll
+    poll();
+
+    // Set up interval polling every 5 seconds
+    pollingRef.current = setInterval(poll, 5000);
+  }, [deviceCodeInfo, isPolling, resetForm, router]);
+
   const handleCopyLink = async () => {
-    if (authUrl) {
-      await navigator.clipboard.writeText(authUrl);
+    const urlToCopy = providerConfig?.flowType === "device_code" 
+      ? deviceCodeInfo?.verificationUrl 
+      : authUrl;
+    
+    if (urlToCopy) {
+      await navigator.clipboard.writeText(urlToCopy);
       toast.success("Link copied to clipboard");
     }
   };
@@ -145,9 +328,8 @@ export function AddAccountDialog() {
     e.preventDefault();
     setError("");
 
-    if (!provider) {
-      setError("Please select a provider first");
-      setStep(1);
+    if (!provider || !providerConfig || providerConfig.flowType !== "oauth_redirect") {
+      setError("Invalid provider configuration");
       return;
     }
 
@@ -164,15 +346,15 @@ export function AddAccountDialog() {
     setIsLoading(true);
 
     try {
-      const result = await PROVIDERS[provider].exchangeAction(callbackUrl.trim());
+      const result = await providerConfig.exchangeAction(callbackUrl.trim());
 
       if (!result.success) {
         throw new Error(result.error);
       }
 
       const message = result.data.isUpdate
-        ? `${PROVIDERS[provider].name} account updated successfully!`
-        : `${PROVIDERS[provider].name} account connected successfully!`;
+        ? `${providerConfig.name} account updated successfully!`
+        : `${providerConfig.name} account connected successfully!`;
 
       toast.success(message);
       setOpen(false);
@@ -187,7 +369,10 @@ export function AddAccountDialog() {
     }
   };
 
-  const providerConfig = provider ? PROVIDERS[provider] : null;
+  const renderProviderIcon = (config: ProviderConfig, className?: string) => {
+    const Icon = config.icon;
+    return <Icon className={cn(className, COLOR_CLASSES[config.color])} />;
+  };
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
@@ -239,92 +424,140 @@ export function AddAccountDialog() {
           {step === 1 && (
             <div className="space-y-4">
               <Label className="text-sm font-medium">Choose a provider</Label>
-              <div className="grid grid-cols-2 gap-3">
-                {(Object.entries(PROVIDERS) as [keyof typeof PROVIDERS, typeof PROVIDERS[keyof typeof PROVIDERS]][]).map(
-                  ([key, config]) => {
-                    const Icon = config.icon;
-                    return (
-                      <button
-                        key={key}
-                        type="button"
-                        onClick={() => handleSelectProvider(key)}
-                        className={cn(
-                          "flex flex-col items-center gap-2 rounded-lg border-2 p-4 text-center transition-all hover:border-primary hover:bg-accent",
-                          provider === key
-                            ? "border-primary bg-accent"
-                            : "border-border"
-                        )}
-                      >
-                        <Icon
-                          className={cn(
-                            "h-8 w-8",
-                            config.color === "blue"
-                              ? "text-blue-500"
-                              : "text-purple-500"
-                          )}
-                        />
-                        <div>
-                          <div className="font-medium">{config.name}</div>
-                          <div className="text-xs text-muted-foreground">
-                            {config.description}
-                          </div>
+              <div className="grid grid-cols-3 gap-3">
+                {(Object.entries(PROVIDERS) as [Exclude<Provider, null>, ProviderFullConfig][]).map(
+                  ([key, config]) => (
+                    <button
+                      key={key}
+                      type="button"
+                      onClick={() => handleSelectProvider(key)}
+                      className={cn(
+                        "flex flex-col items-center gap-2 rounded-lg border-2 p-3 text-center transition-all hover:border-primary hover:bg-accent",
+                        provider === key
+                          ? "border-primary bg-accent"
+                          : "border-border"
+                      )}
+                    >
+                      {renderProviderIcon(config, "h-6 w-6")}
+                      <div>
+                        <div className="text-sm font-medium">{config.name}</div>
+                        <div className="text-[10px] text-muted-foreground leading-tight">
+                          {config.description}
                         </div>
-                      </button>
-                    );
-                  }
+                      </div>
+                    </button>
+                  )
                 )}
               </div>
             </div>
           )}
 
-          {/* Step 2: OAuth Login */}
+          {/* Step 2: OAuth Login / Device Code */}
           {step === 2 && providerConfig && (
             <div className="space-y-4">
-              <div className="space-y-2">
-                <Label className="text-sm font-medium">
-                  Login to {providerConfig.name}
-                </Label>
-                <p className="text-sm text-muted-foreground">
-                  Click the button below to open the login page in a new window.
-                  After logging in, you&apos;ll be redirected to a page that shows
-                  an error - this is expected.
-                </p>
-              </div>
-              <div className="flex gap-2">
-                <Button
-                  onClick={handleStartOAuth}
-                  variant="outline"
-                  className="flex-1"
-                  disabled={isFetchingUrl || !authUrl}
-                >
-                  {isFetchingUrl ? (
-                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                  ) : (
-                    <ExternalLink className="mr-2 h-4 w-4" />
+              {providerConfig.flowType === "oauth_redirect" ? (
+                // OAuth Redirect Flow
+                <>
+                  <div className="space-y-2">
+                    <Label className="text-sm font-medium">
+                      Login to {providerConfig.name}
+                    </Label>
+                    <p className="text-sm text-muted-foreground">
+                      Click the button below to open the login page in a new window.
+                      After logging in, you&apos;ll be redirected to a page that shows
+                      an error - this is expected.
+                    </p>
+                  </div>
+                  <div className="flex gap-2">
+                    <Button
+                      onClick={handleStartOAuth}
+                      variant="outline"
+                      className="flex-1"
+                      disabled={isFetchingUrl || !authUrl}
+                    >
+                      {isFetchingUrl ? (
+                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      ) : (
+                        <ExternalLink className="mr-2 h-4 w-4" />
+                      )}
+                      Open {providerConfig.name} Login
+                    </Button>
+                    <Button
+                      onClick={handleCopyLink}
+                      variant="outline"
+                      disabled={isFetchingUrl || !authUrl}
+                      title="Copy login link"
+                    >
+                      <Copy className="h-4 w-4" />
+                    </Button>
+                  </div>
+                  <Alert>
+                    <AlertCircle className="h-4 w-4" />
+                    <AlertDescription className="text-xs">
+                      After login, copy the URL from address bar:{" "}
+                      <code className="rounded bg-muted px-1">localhost:11451/...?code=...</code>
+                    </AlertDescription>
+                  </Alert>
+                </>
+              ) : (
+                // Device Code Flow
+                <>
+                  <div className="space-y-2">
+                    <Label className="text-sm font-medium">
+                      Login to {providerConfig.name}
+                    </Label>
+                    <p className="text-sm text-muted-foreground">
+                      Click the button below to open the Qwen login page. After you
+                      complete the login, authorization will be detected automatically.
+                    </p>
+                  </div>
+                  <div className="flex gap-2">
+                    <Button
+                      onClick={handleStartDeviceCodeAuth}
+                      variant="outline"
+                      className="flex-1"
+                      disabled={isFetchingUrl || !deviceCodeInfo || isPolling}
+                    >
+                      {isFetchingUrl ? (
+                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      ) : isPolling ? (
+                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      ) : (
+                        <ExternalLink className="mr-2 h-4 w-4" />
+                      )}
+                      {isPolling ? "Waiting for login..." : `Open ${providerConfig.name} Login`}
+                    </Button>
+                    <Button
+                      onClick={handleCopyLink}
+                      variant="outline"
+                      disabled={isFetchingUrl || !deviceCodeInfo}
+                      title="Copy login link"
+                    >
+                      <Copy className="h-4 w-4" />
+                    </Button>
+                  </div>
+                  {isPolling && (
+                    <Alert>
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                      <AlertDescription className="text-xs">
+                        Complete the login in your browser. This dialog will close
+                        automatically when authorization is complete.
+                      </AlertDescription>
+                    </Alert>
                   )}
-                  Open {providerConfig.name} Login
-                </Button>
-                <Button
-                  onClick={handleCopyLink}
-                  variant="outline"
-                  disabled={isFetchingUrl || !authUrl}
-                  title="Copy login link"
-                >
-                  <Copy className="h-4 w-4" />
-                </Button>
-              </div>
-              <Alert>
-                <AlertCircle className="h-4 w-4" />
-                <AlertDescription className="text-xs">
-                  After login, copy the URL from address bar:{" "}
-                  <code className="rounded bg-muted px-1">localhost:11451/...?code=...</code>
-                </AlertDescription>
-              </Alert>
+                  {error && (
+                    <Alert variant="destructive">
+                      <AlertCircle className="h-4 w-4" />
+                      <AlertDescription className="text-xs">{error}</AlertDescription>
+                    </Alert>
+                  )}
+                </>
+              )}
             </div>
           )}
 
-          {/* Step 3: Paste URL */}
-          {step === 3 && providerConfig && (
+          {/* Step 3: Paste URL (OAuth Redirect only) */}
+          {step === 3 && providerConfig && providerConfig.flowType === "oauth_redirect" && (
             <form onSubmit={handleSubmit} className="space-y-4">
               <div className="space-y-2">
                 <Label className="text-sm font-medium">Paste Callback URL</Label>
@@ -348,11 +581,7 @@ export function AddAccountDialog() {
                   </>
                 ) : (
                   <>
-                    {providerConfig.color === "blue" ? (
-                      <Zap className="mr-2 h-4 w-4" />
-                    ) : (
-                      <Sparkles className="mr-2 h-4 w-4" />
-                    )}
+                    {renderProviderIcon(providerConfig, "mr-2 h-4 w-4")}
                     Connect {providerConfig.name} Account
                   </>
                 )}
@@ -363,7 +592,7 @@ export function AddAccountDialog() {
 
         <DialogFooter className="sm:justify-between">
           <div>
-            {step > 1 && (
+            {step > 1 && !isPolling && (
               <Button
                 type="button"
                 variant="ghost"
@@ -376,7 +605,7 @@ export function AddAccountDialog() {
             )}
           </div>
           <div>
-            {step === 2 && (
+            {step === 2 && providerConfig?.flowType === "oauth_redirect" && (
               <Button
                 type="button"
                 variant="ghost"

--- a/app/dashboard/accounts/page.tsx
+++ b/app/dashboard/accounts/page.tsx
@@ -3,7 +3,7 @@ import { prisma } from "@/lib/db";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Alert, AlertDescription } from "@/components/ui/alert";
-import { CheckCircle, XCircle, AlertCircle, Sparkles, Zap } from "lucide-react";
+import { CheckCircle, XCircle, AlertCircle, Sparkles, Zap, Terminal } from "lucide-react";
 import { AccountActions } from "./account-actions";
 import { AddAccountDialog } from "./add-account-dialog";
 
@@ -27,6 +27,7 @@ export default async function AccountsPage({
   // Group accounts by provider
   const iflowAccounts = accounts.filter((a) => a.provider === "iflow");
   const antigravityAccounts = accounts.filter((a) => a.provider === "antigravity");
+  const qwenCodeAccounts = accounts.filter((a) => a.provider === "qwen_code");
 
   return (
     <div className="space-y-4 md:space-y-6">
@@ -46,7 +47,9 @@ export default async function AccountsPage({
           <AlertDescription>
             {params.success === "antigravity_added"
               ? "Antigravity account connected successfully!"
-              : "Account connected successfully!"}
+              : params.success === "qwen_code_added"
+                ? "Qwen Code account connected successfully!"
+                : "Account connected successfully!"}
           </AlertDescription>
         </Alert>
       )}
@@ -103,8 +106,42 @@ export default async function AccountsPage({
           <p className="text-sm text-muted-foreground">No Antigravity accounts connected yet.</p>
         )}
       </div>
+
+      {/* Qwen Code Section */}
+      <div className="space-y-4">
+        <div className="flex items-center gap-2">
+          <Terminal className="h-5 w-5 text-orange-500" />
+          <h3 className="text-base md:text-lg font-semibold">Qwen Code Accounts</h3>
+          <Badge variant="outline" className="text-xs">
+            {qwenCodeAccounts.length} connected
+          </Badge>
+        </div>
+
+        {/* Qwen Code Accounts List */}
+        {qwenCodeAccounts.length > 0 ? (
+          <div className="grid gap-3 sm:gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+            {qwenCodeAccounts.map((account) => (
+              <AccountCard key={account.id} account={account} />
+            ))}
+          </div>
+        ) : (
+          <p className="text-sm text-muted-foreground">No Qwen Code accounts connected yet.</p>
+        )}
+      </div>
     </div>
   );
+}
+
+function getProviderDisplay(provider: string): { name: string; color: string } {
+  switch (provider) {
+    case "antigravity":
+      return { name: "Antigravity", color: "purple" };
+    case "qwen_code":
+      return { name: "Qwen Code", color: "orange" };
+    case "iflow":
+    default:
+      return { name: "iFlow", color: "blue" };
+  }
 }
 
 function AccountCard({ 
@@ -124,7 +161,7 @@ function AccountCard({
   };
   showTier?: boolean;
 }) {
-  const providerColor = account.provider === "antigravity" ? "purple" : "blue";
+  const { name: providerName, color: providerColor } = getProviderDisplay(account.provider);
   
   return (
     <Card>
@@ -165,7 +202,7 @@ function AccountCard({
               variant="outline" 
               className={`text-${providerColor}-600 border-${providerColor}-300`}
             >
-              {account.provider === "antigravity" ? "Antigravity" : "iFlow"}
+              {providerName}
             </Badge>
           </div>
           <div className="flex justify-between">

--- a/app/dashboard/models/page.tsx
+++ b/app/dashboard/models/page.tsx
@@ -21,6 +21,8 @@ function getProviderLabel(provider: string): string {
       return "iFlow";
     case ProviderName.ANTIGRAVITY:
       return "Antigravity";
+    case ProviderName.QWEN_CODE:
+      return "Qwen Code";
     default:
       return provider;
   }
@@ -36,7 +38,11 @@ export default async function ModelsPage() {
   // Get all models grouped by provider
   const iflowModels = getModelsForProvider(ProviderName.IFLOW);
   const antigravityModels = getModelsForProvider(ProviderName.ANTIGRAVITY);
+  const qwenCodeModels = getModelsForProvider(ProviderName.QWEN_CODE);
   const allModels = Object.keys(MODEL_REGISTRY);
+
+  // Count active providers
+  const activeProviders = [iflowModels, antigravityModels, qwenCodeModels].filter(m => m.length > 0).length;
 
   const usageStats = await prisma.usageLog.groupBy({
     by: ["model"],
@@ -60,13 +66,14 @@ export default async function ModelsPage() {
 
   const iflowModelsWithStats = modelsWithStats.filter(m => m.providers.includes(ProviderName.IFLOW));
   const antigravityModelsWithStats = modelsWithStats.filter(m => m.providers.includes(ProviderName.ANTIGRAVITY));
+  const qwenCodeModelsWithStats = modelsWithStats.filter(m => m.providers.includes(ProviderName.QWEN_CODE));
 
   return (
     <div className="space-y-6 md:space-y-8">
       <div>
         <h2 className="text-xl md:text-2xl font-bold tracking-tight">Available Models</h2>
         <p className="text-sm md:text-base text-muted-foreground">
-          Browse all {allModels.length} available models across {iflowModels.length > 0 && antigravityModels.length > 0 ? "2 providers" : "1 provider"}
+          Browse all {allModels.length} available models across {activeProviders} provider{activeProviders !== 1 ? "s" : ""}
         </p>
       </div>
 
@@ -103,6 +110,28 @@ export default async function ModelsPage() {
           </div>
           <div className="grid gap-3 sm:gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
             {antigravityModelsWithStats.map((model) => (
+              <ModelCard
+                key={model.id}
+                id={model.id}
+                category={model.category}
+                usage={model.usage}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Qwen Code Models */}
+      {qwenCodeModelsWithStats.length > 0 && (
+        <div className="space-y-4">
+          <div className="flex items-center gap-2">
+            <h3 className="text-lg font-semibold">Qwen Code Models</h3>
+            <span className="text-xs text-muted-foreground bg-muted px-2 py-0.5 rounded-full">
+              {qwenCodeModels.length}
+            </span>
+          </div>
+          <div className="grid gap-3 sm:gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+            {qwenCodeModelsWithStats.map((model) => (
               <ModelCard
                 key={model.id}
                 id={model.id}

--- a/lib/proxy/models.ts
+++ b/lib/proxy/models.ts
@@ -23,7 +23,7 @@ export const MODEL_REGISTRY: Record<string, ModelInfo> = {
   "iflow-rome-30ba3b": { providers: [ProviderName.IFLOW] },
   "minimax-m2.1": { providers: [ProviderName.IFLOW] },
   "minimax-m2": { providers: [ProviderName.IFLOW] },
-  "qwen3-coder-plus": { providers: [ProviderName.IFLOW] },
+  "qwen3-coder-plus": { providers: [ProviderName.IFLOW, ProviderName.QWEN_CODE] },
   "kimi-k2": { providers: [ProviderName.IFLOW] },
   "kimi-k2-0905": { providers: [ProviderName.IFLOW] },
   "kimi-k2-thinking": { providers: [ProviderName.IFLOW] },
@@ -79,6 +79,9 @@ export const MODEL_REGISTRY: Record<string, ModelInfo> = {
 
   // Other Antigravity models
   "gpt-oss-120b-medium": { providers: [ProviderName.ANTIGRAVITY] },
+
+  // ===== Qwen Code Models =====
+  "qwen3-coder-flash": { providers: [ProviderName.QWEN_CODE] },
 };
 
 // Build reverse lookup for aliases

--- a/lib/proxy/providers/qwen-code/client.ts
+++ b/lib/proxy/providers/qwen-code/client.ts
@@ -1,0 +1,583 @@
+// Qwen Code Provider Implementation
+// Uses Device Code Flow for OAuth (similar to TV/device authentication)
+
+import type { ProviderAccount } from "@prisma/client";
+import { encrypt, decrypt } from "@/lib/encryption";
+import { prisma } from "@/lib/db";
+import type {
+  Provider,
+  ProviderConfig,
+  OAuthResult,
+  ChatCompletionRequest,
+} from "../types";
+import {
+  QWEN_CODE_CLIENT_ID,
+  QWEN_CODE_SCOPE,
+  QWEN_CODE_TOKEN_ENDPOINT,
+  QWEN_CODE_DEVICE_CODE_ENDPOINT,
+  QWEN_CODE_API_BASE_URL,
+  QWEN_CODE_SUPPORTED_PARAMS,
+  QWEN_CODE_MODELS,
+  QWEN_CODE_REFRESH_BUFFER_SECONDS,
+} from "./constants";
+
+/**
+ * Device code response from Qwen API
+ */
+export interface DeviceCodeResponse {
+  device_code: string;
+  user_code: string;
+  verification_uri: string;
+  verification_uri_complete: string;
+  expires_in: number;
+  interval: number;
+}
+
+/**
+ * Token response from Qwen API
+ */
+interface TokenResponse {
+  access_token: string;
+  refresh_token: string;
+  expires_in: number;
+  token_type: string;
+  resource_url?: string;
+}
+
+/**
+ * Generate PKCE code verifier
+ */
+function generateCodeVerifier(): string {
+  const array = new Uint8Array(32);
+  crypto.getRandomValues(array);
+  // Base64url encode
+  return btoa(String.fromCharCode(...array))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+/**
+ * Generate PKCE code challenge from verifier
+ */
+async function generateCodeChallenge(verifier: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(verifier);
+  const digest = await crypto.subtle.digest("SHA-256", data);
+  const base64 = btoa(String.fromCharCode(...new Uint8Array(digest)));
+  return base64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+/**
+ * Check if token needs refresh (with buffer)
+ */
+function isTokenExpired(expiresAt: Date): boolean {
+  const bufferMs = QWEN_CODE_REFRESH_BUFFER_SECONDS * 1000;
+  return new Date().getTime() > expiresAt.getTime() - bufferMs;
+}
+
+/**
+ * Clean tool schemas to prevent API errors
+ */
+function cleanToolSchemas(
+  tools: Array<{ type: string; function: Record<string, unknown> }>
+): Array<{ type: string; function: Record<string, unknown> }> {
+  return tools.map((tool) => {
+    const cleaned = { ...tool };
+
+    if (cleaned.function) {
+      // Remove unsupported properties
+      delete cleaned.function.strict;
+
+      if (cleaned.function.parameters) {
+        delete (cleaned.function.parameters as Record<string, unknown>)
+          .additionalProperties;
+
+        // Recursively clean nested properties
+        if (
+          (cleaned.function.parameters as Record<string, unknown>).properties
+        ) {
+          cleanSchemaProperties(
+            (cleaned.function.parameters as Record<string, unknown>)
+              .properties as Record<string, unknown>
+          );
+        }
+      }
+    }
+
+    return cleaned;
+  });
+}
+
+function cleanSchemaProperties(properties: Record<string, unknown>): void {
+  for (const key of Object.keys(properties)) {
+    const prop = properties[key] as Record<string, unknown>;
+    delete prop.additionalProperties;
+    delete prop.strict;
+
+    if (prop.properties) {
+      cleanSchemaProperties(prop.properties as Record<string, unknown>);
+    }
+
+    if ((prop.items as Record<string, unknown>)?.properties) {
+      cleanSchemaProperties(
+        (prop.items as Record<string, unknown>).properties as Record<
+          string,
+          unknown
+        >
+      );
+    }
+  }
+}
+
+/**
+ * Build request payload with only supported parameters
+ */
+function buildRequestPayload(
+  params: Record<string, unknown>,
+  forceStream?: boolean
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(params)) {
+    if (QWEN_CODE_SUPPORTED_PARAMS.has(key) && value !== undefined) {
+      payload[key] = value;
+    }
+  }
+
+  // Use stream value from params, or force if specified
+  if (forceStream !== undefined) {
+    payload.stream = forceStream;
+  } else if (payload.stream === undefined) {
+    payload.stream = true; // Default to streaming
+  }
+
+  // Always include usage data in stream
+  if (payload.stream === true) {
+    payload.stream_options = { include_usage: true };
+  }
+
+  // Clean tool schemas if present
+  if (payload.tools && Array.isArray(payload.tools)) {
+    if (payload.tools.length > 0) {
+      payload.tools = cleanToolSchemas(
+        payload.tools as Array<{ type: string; function: Record<string, unknown> }>
+      );
+    } else if (payload.stream === true) {
+      // Per Qwen Code API bug, injecting a dummy tool prevents stream corruption
+      // when no tools are provided
+      payload.tools = [
+        {
+          type: "function",
+          function: {
+            name: "do_not_call_me",
+            description: "Do not call this tool.",
+            parameters: { type: "object", properties: {} },
+          },
+        },
+      ];
+    }
+  }
+
+  return payload;
+}
+
+export const qwenCodeConfig: ProviderConfig = {
+  name: "qwen_code",
+  displayName: "Qwen Code",
+  supportedModels: QWEN_CODE_MODELS,
+};
+
+export const qwenCodeProvider: Provider = {
+  config: qwenCodeConfig,
+
+  /**
+   * For Device Code Flow, we don't use a traditional auth URL.
+   * Instead, we initiate device code flow and return the verification URL.
+   * This method is kept for interface compatibility but shouldn't be called directly.
+   */
+  getAuthUrl(_state: string, _codeVerifier?: string): string {
+    // Device code flow doesn't use a redirect-based auth URL
+    // The actual URL is obtained from initiateDeviceCodeFlow()
+    throw new Error(
+      "Qwen Code uses Device Code Flow. Use initiateDeviceCodeFlow() instead."
+    );
+  },
+
+  /**
+   * Exchange device code for tokens (called after user completes auth)
+   * For Qwen Code, this is called with the device_code as the "code" parameter
+   */
+  async exchangeCode(
+    code: string,
+    _redirectUri: string,
+    codeVerifier?: string
+  ): Promise<OAuthResult> {
+    const body: Record<string, string> = {
+      grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+      device_code: code,
+      client_id: QWEN_CODE_CLIENT_ID,
+    };
+
+    if (codeVerifier) {
+      body.code_verifier = codeVerifier;
+    }
+
+    const response = await fetch(QWEN_CODE_TOKEN_ENDPOINT, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Accept: "application/json",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+      },
+      body: new URLSearchParams(body),
+    });
+
+    if (!response.ok) {
+      const error = await response.text();
+      throw new Error(`Token exchange failed: ${response.status} ${error}`);
+    }
+
+    const tokens: TokenResponse = await response.json();
+
+    return {
+      accessToken: tokens.access_token,
+      refreshToken: tokens.refresh_token,
+      expiresAt: new Date(Date.now() + tokens.expires_in * 1000),
+      email: "", // Email will be set from user input during device flow
+    };
+  },
+
+  async refreshToken(refreshToken: string): Promise<OAuthResult> {
+    const response = await fetch(QWEN_CODE_TOKEN_ENDPOINT, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Accept: "application/json",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+      },
+      body: new URLSearchParams({
+        grant_type: "refresh_token",
+        refresh_token: refreshToken,
+        client_id: QWEN_CODE_CLIENT_ID,
+      }),
+    });
+
+    if (!response.ok) {
+      const error = await response.text();
+      throw new Error(`Token refresh failed: ${response.status} ${error}`);
+    }
+
+    const tokens: TokenResponse = await response.json();
+
+    return {
+      accessToken: tokens.access_token,
+      // Qwen uses rotating refresh tokens - new token replaces old one
+      refreshToken: tokens.refresh_token ?? refreshToken,
+      expiresAt: new Date(Date.now() + tokens.expires_in * 1000),
+      email: "", // Preserve from existing account
+    };
+  },
+
+  async getValidCredentials(account: ProviderAccount): Promise<string> {
+    let accessToken = decrypt(account.accessToken);
+    const refreshTokenValue = decrypt(account.refreshToken);
+
+    // Check if token needs refresh
+    if (isTokenExpired(account.expiresAt)) {
+      console.log(`Refreshing token for Qwen Code account ${account.id}`);
+
+      try {
+        const newTokens = await this.refreshToken(refreshTokenValue);
+
+        // Update database IMMEDIATELY (rotating token concern)
+        // Qwen uses rotating refresh tokens - must save new token before it's invalidated
+        await prisma.providerAccount.update({
+          where: { id: account.id },
+          data: {
+            accessToken: encrypt(newTokens.accessToken),
+            refreshToken: encrypt(newTokens.refreshToken),
+            expiresAt: newTokens.expiresAt,
+          },
+        });
+
+        accessToken = newTokens.accessToken;
+        console.log(
+          `Token refreshed successfully for Qwen Code account ${account.id}`
+        );
+      } catch (error) {
+        console.error(
+          `Failed to refresh token for Qwen Code account ${account.id}:`,
+          error
+        );
+        // If refresh fails but token not truly expired, try using existing
+        if (new Date() < account.expiresAt) {
+          console.log("Using existing token as fallback");
+        } else {
+          throw error;
+        }
+      }
+    }
+
+    return accessToken;
+  },
+
+  async makeRequest(
+    accessToken: string,
+    _account: ProviderAccount,
+    body: ChatCompletionRequest,
+    stream: boolean
+  ): Promise<Response> {
+    // Strip provider prefix from model name
+    const modelName = body.model.includes("/")
+      ? body.model.split("/").pop()!
+      : body.model;
+
+    const requestPayload = buildRequestPayload(
+      {
+        ...body,
+        model: modelName,
+      },
+      stream
+    );
+
+    const response = await fetch(`${QWEN_CODE_API_BASE_URL}/chat/completions`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+        Accept: stream ? "text/event-stream" : "application/json",
+        "User-Agent": "google-api-nodejs-client/9.15.1",
+        "X-Goog-Api-Client": "gl-node/22.17.0",
+        "Client-Metadata":
+          "ideType=IDE_UNSPECIFIED,platform=PLATFORM_UNSPECIFIED,pluginType=GEMINI",
+      },
+      body: JSON.stringify(requestPayload),
+    });
+
+    // For streaming responses, transform to handle <think> tags
+    if (stream && response.ok && response.body) {
+      const transformedBody = response.body
+        .pipeThrough(new TextDecoderStream())
+        .pipeThrough(createThinkTagTransform(modelName))
+        .pipeThrough(new TextEncoderStream());
+
+      return new Response(transformedBody, {
+        status: response.status,
+        statusText: response.statusText,
+        headers: new Headers({
+          "Content-Type": "text/event-stream",
+          "Cache-Control": "no-cache",
+          Connection: "keep-alive",
+        }),
+      });
+    }
+
+    return response;
+  },
+};
+
+/**
+ * Initiate Device Code Flow
+ * Returns device code info including URL for user to visit
+ */
+export async function initiateDeviceCodeFlow(): Promise<{
+  deviceCode: string;
+  userCode: string;
+  verificationUrl: string;
+  verificationUrlComplete: string;
+  expiresIn: number;
+  interval: number;
+  codeVerifier: string;
+}> {
+  const codeVerifier = generateCodeVerifier();
+  const codeChallenge = await generateCodeChallenge(codeVerifier);
+
+  const response = await fetch(QWEN_CODE_DEVICE_CODE_ENDPOINT, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      Accept: "application/json",
+      "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+    },
+    body: new URLSearchParams({
+      client_id: QWEN_CODE_CLIENT_ID,
+      scope: QWEN_CODE_SCOPE,
+      code_challenge: codeChallenge,
+      code_challenge_method: "S256",
+    }),
+  });
+
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(`Device code request failed: ${response.status} ${error}`);
+  }
+
+  const data: DeviceCodeResponse = await response.json();
+
+  return {
+    deviceCode: data.device_code,
+    userCode: data.user_code,
+    verificationUrl: data.verification_uri,
+    verificationUrlComplete: data.verification_uri_complete,
+    expiresIn: data.expires_in,
+    interval: data.interval,
+    codeVerifier,
+  };
+}
+
+/**
+ * Poll for device code authorization
+ * Returns tokens when user completes auth, or null if still pending
+ */
+export async function pollDeviceCodeAuthorization(
+  deviceCode: string,
+  codeVerifier: string
+): Promise<OAuthResult | { pending: true } | { error: string }> {
+  const response = await fetch(QWEN_CODE_TOKEN_ENDPOINT, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      Accept: "application/json",
+      "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+    },
+    body: new URLSearchParams({
+      grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+      device_code: deviceCode,
+      client_id: QWEN_CODE_CLIENT_ID,
+      code_verifier: codeVerifier,
+    }),
+  });
+
+  if (response.status === 200) {
+    const tokens: TokenResponse = await response.json();
+    return {
+      accessToken: tokens.access_token,
+      refreshToken: tokens.refresh_token,
+      expiresAt: new Date(Date.now() + tokens.expires_in * 1000),
+      email: "",
+    };
+  }
+
+  if (response.status === 400) {
+    const errorData = await response.json();
+    const errorType = errorData.error;
+
+    if (errorType === "authorization_pending") {
+      return { pending: true };
+    }
+
+    if (errorType === "slow_down") {
+      return { pending: true };
+    }
+
+    if (errorType === "expired_token") {
+      return { error: "Device code expired. Please start again." };
+    }
+
+    if (errorType === "access_denied") {
+      return { error: "Authorization was denied by the user." };
+    }
+
+    return { error: errorData.error_description || errorType };
+  }
+
+  const error = await response.text();
+  return { error: `Unexpected error: ${response.status} ${error}` };
+}
+
+/**
+ * Create transform stream to handle <think> tags in Qwen responses
+ * Converts <think>...</think> to reasoning_content field
+ */
+function createThinkTagTransform(_model: string): TransformStream<string, string> {
+  let buffer = "";
+  let inThinkingBlock = false;
+
+  return new TransformStream<string, string>({
+    transform(chunk, controller) {
+      buffer += chunk;
+
+      // Process complete lines
+      const lines = buffer.split("\n");
+      buffer = lines.pop() || ""; // Keep incomplete line in buffer
+
+      for (const line of lines) {
+        if (!line.startsWith("data: ")) {
+          controller.enqueue(line + "\n");
+          continue;
+        }
+
+        const jsonStr = line.slice(6).trim();
+        if (jsonStr === "[DONE]") {
+          controller.enqueue(line + "\n");
+          continue;
+        }
+
+        try {
+          const parsed = JSON.parse(jsonStr);
+          const choices = parsed.choices || [];
+
+          for (const choice of choices) {
+            const delta = choice.delta || {};
+            const content = delta.content;
+
+            if (typeof content === "string") {
+              // Handle <think> tags
+              let processedContent = content;
+              let reasoningContent: string | undefined;
+
+              if (content.includes("<think>")) {
+                inThinkingBlock = true;
+                const parts = content.split("<think>");
+                processedContent = parts[0];
+                if (parts[1]) {
+                  reasoningContent = parts[1];
+                }
+              }
+
+              if (inThinkingBlock && content.includes("</think>")) {
+                inThinkingBlock = false;
+                const parts = content.split("</think>");
+                if (!reasoningContent) {
+                  reasoningContent = parts[0];
+                } else {
+                  reasoningContent += parts[0];
+                }
+                processedContent = parts[1] || "";
+              }
+
+              if (inThinkingBlock && !content.includes("<think>")) {
+                reasoningContent = content;
+                processedContent = "";
+              }
+
+              // Update delta
+              if (reasoningContent) {
+                delta.reasoning_content = reasoningContent;
+              }
+              if (processedContent !== content) {
+                delta.content = processedContent || null;
+              }
+            }
+          }
+
+          // Re-serialize and output
+          const output = `data: ${JSON.stringify(parsed)}\n`;
+          controller.enqueue(output);
+        } catch {
+          // Pass through unparseable lines
+          controller.enqueue(line + "\n");
+        }
+      }
+    },
+    flush(controller) {
+      if (buffer) {
+        controller.enqueue(buffer);
+      }
+    },
+  });
+}
+
+// Export utilities
+export { generateCodeVerifier, generateCodeChallenge };

--- a/lib/proxy/providers/qwen-code/constants.ts
+++ b/lib/proxy/providers/qwen-code/constants.ts
@@ -1,0 +1,47 @@
+// Qwen Code OAuth and API Constants
+// Based on https://github.com/Mirrowel/LLM-API-Key-Proxy
+
+// OAuth Configuration (Device Code Flow)
+// Client ID from https://api.kilocode.ai/extension-config.json
+export const QWEN_CODE_CLIENT_ID = "f0304373b74a44d2b584a3fb70ca9e56";
+export const QWEN_CODE_SCOPE = "openid profile email model.completion";
+
+// OAuth Endpoints
+export const QWEN_CODE_TOKEN_ENDPOINT = "https://chat.qwen.ai/api/v1/oauth2/token";
+export const QWEN_CODE_DEVICE_CODE_ENDPOINT = "https://chat.qwen.ai/api/v1/oauth2/device/code";
+
+// API Endpoint
+export const QWEN_CODE_API_BASE_URL = "https://portal.qwen.ai/v1";
+
+// Supported OpenAI-compatible parameters for Qwen Code API
+export const QWEN_CODE_SUPPORTED_PARAMS = new Set([
+  "model",
+  "messages",
+  "temperature",
+  "top_p",
+  "max_tokens",
+  "stream",
+  "tools",
+  "tool_choice",
+  "presence_penalty",
+  "frequency_penalty",
+  "n",
+  "stop",
+  "seed",
+  "response_format",
+]);
+
+// Available Qwen Code models
+export const QWEN_CODE_MODELS = new Set([
+  "qwen3-coder-plus",
+  "qwen3-coder-flash",
+]);
+
+// Token refresh buffer (3 hours before expiry)
+export const QWEN_CODE_REFRESH_BUFFER_SECONDS = 3 * 60 * 60;
+
+// Device code polling interval (seconds)
+export const QWEN_CODE_POLLING_INTERVAL = 5;
+
+// Device code expiry timeout (seconds)
+export const QWEN_CODE_DEVICE_CODE_EXPIRY = 600; // 10 minutes

--- a/lib/proxy/providers/qwen-code/index.ts
+++ b/lib/proxy/providers/qwen-code/index.ts
@@ -1,0 +1,11 @@
+// Qwen Code Provider exports
+
+export { qwenCodeProvider, qwenCodeConfig } from "./client";
+export {
+  initiateDeviceCodeFlow,
+  pollDeviceCodeAuthorization,
+  generateCodeVerifier,
+  generateCodeChallenge,
+} from "./client";
+export type { DeviceCodeResponse } from "./client";
+export * from "./constants";

--- a/lib/proxy/providers/registry.ts
+++ b/lib/proxy/providers/registry.ts
@@ -6,6 +6,7 @@ import { ProviderName } from "./types";
 // Provider instances will be lazily imported
 let iflowProvider: Provider | null = null;
 let antigravityProvider: Provider | null = null;
+let qwenCodeProvider: Provider | null = null;
 
 /**
  * Get a provider instance by name
@@ -26,6 +27,13 @@ export async function getProvider(name: ProviderNameType): Promise<Provider> {
       }
       return antigravityProvider;
 
+    case ProviderName.QWEN_CODE:
+      if (!qwenCodeProvider) {
+        const { qwenCodeProvider: provider } = await import("./qwen-code");
+        qwenCodeProvider = provider;
+      }
+      return qwenCodeProvider;
+
     default:
       throw new Error(`Unknown provider: ${name}`);
   }
@@ -35,11 +43,12 @@ export async function getProvider(name: ProviderNameType): Promise<Provider> {
  * Get all available providers
  */
 export async function getAllProviders(): Promise<Provider[]> {
-  const [iflow, antigravity] = await Promise.all([
+  const [iflow, antigravity, qwenCode] = await Promise.all([
     getProvider(ProviderName.IFLOW),
     getProvider(ProviderName.ANTIGRAVITY),
+    getProvider(ProviderName.QWEN_CODE),
   ]);
-  return [iflow, antigravity];
+  return [iflow, antigravity, qwenCode];
 }
 
 /**

--- a/lib/proxy/providers/types.ts
+++ b/lib/proxy/providers/types.ts
@@ -144,6 +144,7 @@ export interface Provider {
 export const ProviderName = {
   IFLOW: "iflow",
   ANTIGRAVITY: "antigravity",
+  QWEN_CODE: "qwen_code",
 } as const;
 
 export type ProviderNameType = (typeof ProviderName)[keyof typeof ProviderName];

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -71,7 +71,7 @@ model VerificationToken {
 model ProviderAccount {
   id       String @id @default(cuid())
   userId   String
-  provider String // "iflow" | "antigravity"
+  provider String // "iflow" | "antigravity" | "qwen_code"
   name     String // Display name: "Personal", "Work", etc.
 
   // Encrypted credentials (AES-256 encrypted)


### PR DESCRIPTION
## Summary

- Add new Qwen Code provider with Device Code Flow OAuth authentication
- Support for `qwen3-coder-flash` and `qwen3-coder-plus` models
- Dashboard UI updates for managing Qwen Code accounts

## Changes

### New Files
- `lib/proxy/providers/qwen-code/` - Provider implementation with:
  - Device Code Flow OAuth with PKCE
  - Rotating refresh token support
  - Think tag transform (`<think>` → `reasoning_content`)
  - Dummy tool injection for stream stability

### Modified Files
- `lib/proxy/providers/types.ts` - Add `QWEN_CODE` to ProviderName
- `lib/proxy/providers/registry.ts` - Register qwen-code provider
- `lib/proxy/models.ts` - Add qwen3-coder models
- `lib/actions/accounts.ts` - Add Device Code Flow server actions
- `app/dashboard/accounts/add-account-dialog.tsx` - Support Device Code Flow UI with auto-polling
- `app/dashboard/accounts/page.tsx` - Add Qwen Code accounts section
- `app/dashboard/models/page.tsx` - Add Qwen Code models section
- `prisma/schema.prisma` - Update provider comment

## Testing

Tested with API calls:
- ✅ `qwen3-coder-flash` streaming
- ✅ `qwen3-coder-flash` non-streaming
- ✅ `qwen3-coder-plus` (dual provider: iFlow + Qwen Code)