### PR TITLE
fix: simplify account health recovery

### DIFF
--- a/apps/dashboard/app/components/ProviderAccountCard.vue
+++ b/apps/dashboard/app/components/ProviderAccountCard.vue
@@ -611,11 +611,11 @@ function historyEntryPreview(errorMessage: string): string {
             </UiBadge>
             <UiBadge v-if="account.status === 'failed'" variant="destructive" class="gap-1">
               <UiIcon name="i-lucide-alert-circle" class="size-3" />
-              Failed
+              {{ account.consecutiveErrors }}
             </UiBadge>
             <UiBadge v-else-if="account.status === 'degraded'" variant="outline" class="border-yellow-500 text-yellow-600 gap-1">
               <UiIcon name="i-lucide-triangle-alert" class="size-3" />
-              Degraded ({{ account.consecutiveErrors }})
+              {{ account.consecutiveErrors }}
             </UiBadge>
             <UiBadge v-else-if="account.status === 'half_open'" variant="outline" class="border-yellow-500 text-yellow-600 gap-1">
               <UiIcon name="i-lucide-activity" class="size-3" />

--- a/apps/dashboard/lib/dashboard-api-types.ts
+++ b/apps/dashboard/lib/dashboard-api-types.ts
@@ -26,7 +26,7 @@ export interface ProviderAccountItem {
   requestCount: number;
   tier: string | null;
   status: string;
-  statusReason: string | null;
+  statusChangedAt: string | Date | null;
   errorCount: number;
   consecutiveErrors: number;
   lastErrorAt: string | Date | null;

--- a/apps/dashboard/server/lib/db/schema.ts
+++ b/apps/dashboard/server/lib/db/schema.ts
@@ -135,7 +135,6 @@ export const providerAccount = pgTable(
 
     // Health status
     status: text("status").notNull().default("active"),
-    statusReason: text("statusReason"),
     statusChangedAt: timestamp("statusChangedAt"),
 
     // Success metrics
@@ -347,7 +346,6 @@ export const providerAccountModelHealth = pgTable(
 
     consecutiveErrors: integer("consecutiveErrors").notNull().default(0),
     status: text("status").notNull().default("active"),
-    statusReason: text("statusReason"),
     statusChangedAt: timestamp("statusChangedAt"),
 
     lastErrorAt: timestamp("lastErrorAt"),

--- a/apps/dashboard/server/services/accounts.ts
+++ b/apps/dashboard/server/services/accounts.ts
@@ -11,8 +11,8 @@ export { createAccount, createAccountInputSchema } from "./account-connectors";
 
 const AUTO_PIN_SENTINEL = "_auto_pinned";
 const ACCOUNT_HEALTH_STATUS_WEIGHT: Record<string, number> = { active: 0, degraded: 1, half_open: 2, failed: 3 };
+const FAILED_COOLDOWN_MS = 10 * 60 * 1000;
 const INITIAL_DEGRADED_CONSECUTIVE_ERRORS = 3;
-const MANUAL_REENABLE_STATUS_REASON = "manually re-enabled after failure";
 
 export const providerInputSchema = z.object({
   provider: z.string().refine(isKnownProvider, "Invalid provider"),
@@ -36,7 +36,7 @@ const providerAccountListColumns = {
   requestCount: providerAccount.requestCount,
   tier: providerAccount.tier,
   status: providerAccount.status,
-  statusReason: providerAccount.statusReason,
+  statusChangedAt: providerAccount.statusChangedAt,
   errorCount: providerAccount.errorCount,
   consecutiveErrors: providerAccount.consecutiveErrors,
   lastErrorAt: providerAccount.lastErrorAt,
@@ -58,6 +58,15 @@ function accountIsEffectivelyActive(account: { isActive: boolean; disabledUntil:
 
 function withEffectiveActive<T extends { isActive: boolean; disabledUntil: Date | string | null }>(account: T, now = new Date()): T {
   return { ...account, isActive: accountIsEffectivelyActive(account, now) };
+}
+
+function withEffectiveHealthStatus<T extends { status: string; statusChangedAt?: Date | string | null }>(row: T, now = new Date()): T {
+  if (row.status !== "failed" || !row.statusChangedAt) return row;
+
+  const statusChangedAt = row.statusChangedAt instanceof Date ? row.statusChangedAt : new Date(row.statusChangedAt);
+  if (Number.isNaN(statusChangedAt.getTime()) || now.getTime() - statusChangedAt.getTime() < FAILED_COOLDOWN_MS) return row;
+
+  return { ...row, status: "degraded" };
 }
 
 async function getPinnedProviderKeys(userId: string, providersWithAccounts?: Iterable<string>): Promise<ProviderAccountKey[]> {
@@ -181,7 +190,7 @@ export async function getAccountsByProviderDetailed(userId: string, input: z.inf
             .select({
               providerAccountId: providerAccountModelHealth.providerAccountId,
               status: providerAccountModelHealth.status,
-              statusReason: providerAccountModelHealth.statusReason,
+              statusChangedAt: providerAccountModelHealth.statusChangedAt,
               consecutiveErrors: providerAccountModelHealth.consecutiveErrors,
               lastErrorAt: providerAccountModelHealth.lastErrorAt,
               lastErrorMessage: providerAccountModelHealth.lastErrorMessage,
@@ -199,7 +208,8 @@ export async function getAccountsByProviderDetailed(userId: string, input: z.inf
       return acc;
     }, {});
 
-    const healthByAccountId = healthRows.reduce<Record<string, (typeof healthRows)[number]>>((acc, row) => {
+    const effectiveHealthRows = healthRows.map((row) => withEffectiveHealthStatus(row, now));
+    const healthByAccountId = effectiveHealthRows.reduce<Record<string, (typeof effectiveHealthRows)[number]>>((acc, row) => {
       const current = acc[row.providerAccountId];
       const currentWeight = current ? ACCOUNT_HEALTH_STATUS_WEIGHT[current.status] ?? 0 : 0;
       const nextWeight = ACCOUNT_HEALTH_STATUS_WEIGHT[row.status] ?? 0;
@@ -211,17 +221,18 @@ export async function getAccountsByProviderDetailed(userId: string, input: z.inf
 
     return {
       accounts: accounts.map((account) => {
-        const health = healthByAccountId[account.id];
-        const accountWeight = ACCOUNT_HEALTH_STATUS_WEIGHT[account.status] ?? 0;
+        const effectiveAccount = withEffectiveHealthStatus(account, now);
+        const health = healthByAccountId[effectiveAccount.id];
+        const accountWeight = ACCOUNT_HEALTH_STATUS_WEIGHT[effectiveAccount.status] ?? 0;
         const healthWeight = health ? ACCOUNT_HEALTH_STATUS_WEIGHT[health.status] ?? 0 : 0;
-        const useModelHealth = health && (healthWeight > accountWeight || (healthWeight === accountWeight && health.consecutiveErrors > account.consecutiveErrors));
+        const useModelHealth = health && (healthWeight > accountWeight || (healthWeight === accountWeight && health.consecutiveErrors > effectiveAccount.consecutiveErrors));
 
         return {
-          ...withEffectiveActive(account, now),
+          ...withEffectiveActive(effectiveAccount, now),
           ...(useModelHealth
             ? {
                 status: health.status,
-                statusReason: health.statusReason,
+                statusChangedAt: health.statusChangedAt,
                 consecutiveErrors: health.consecutiveErrors,
                 lastErrorAt: health.lastErrorAt ?? account.lastErrorAt,
                 lastErrorMessage: health.lastErrorMessage ?? account.lastErrorMessage,
@@ -286,11 +297,11 @@ async function downgradeAccountFailureForManualEnable(accountId: string, now = n
   await Promise.all([
     db
       .update(providerAccount)
-      .set({ status: "degraded", statusReason: MANUAL_REENABLE_STATUS_REASON, statusChangedAt: now, consecutiveErrors: INITIAL_DEGRADED_CONSECUTIVE_ERRORS })
+      .set({ status: "degraded", statusChangedAt: now, consecutiveErrors: INITIAL_DEGRADED_CONSECUTIVE_ERRORS })
       .where(and(eq(providerAccount.id, accountId), inArray(providerAccount.status, ["failed", "half_open", "degraded"]))),
     db
       .update(providerAccountModelHealth)
-      .set({ status: "degraded", statusReason: MANUAL_REENABLE_STATUS_REASON, statusChangedAt: now, consecutiveErrors: INITIAL_DEGRADED_CONSECUTIVE_ERRORS })
+      .set({ status: "degraded", statusChangedAt: now, consecutiveErrors: INITIAL_DEGRADED_CONSECUTIVE_ERRORS })
       .where(and(eq(providerAccountModelHealth.providerAccountId, accountId), inArray(providerAccountModelHealth.status, ["failed", "half_open", "degraded"]))),
   ]);
 }
@@ -386,7 +397,7 @@ export async function resolveAccountErrors(userId: string, input: z.infer<typeof
         lastErrorMessage: null,
         lastErrorCode: null,
         lastRecoveredByRotationAt: null,
-        ...(account.status === "degraded" || account.status === "failed" ? { status: "active", statusReason: null, statusChangedAt: new Date() } : {}),
+        ...(account.status === "degraded" || account.status === "failed" ? { status: "active", statusChangedAt: new Date() } : {}),
       })
       .where(eq(providerAccount.id, input.accountId));
     await db.delete(providerAccountErrorHistory).where(eq(providerAccountErrorHistory.providerAccountId, input.accountId));

--- a/apps/proxy/internal/db/db.go
+++ b/apps/proxy/internal/db/db.go
@@ -56,7 +56,6 @@ type ProviderAccount struct {
 	LastErrorCode             *int       `bun:"lastErrorCode"`
 	LastRecoveredByRotationAt *time.Time `bun:"lastRecoveredByRotationAt"`
 	Status                    string     `bun:"status"`
-	StatusReason              *string    `bun:"statusReason"`
 	StatusChangedAt           *time.Time `bun:"statusChangedAt"`
 	SuccessCount              int        `bun:"successCount"`
 	LastSuccessAt             *time.Time `bun:"lastSuccessAt"`
@@ -142,7 +141,6 @@ type ProviderAccountModelHealth struct {
 	Model             string     `bun:"model"`
 	ConsecutiveErrors int        `bun:"consecutiveErrors"`
 	Status            string     `bun:"status"`
-	StatusReason      *string    `bun:"statusReason"`
 	StatusChangedAt   *time.Time `bun:"statusChangedAt"`
 	LastErrorAt       *time.Time `bun:"lastErrorAt"`
 	LastErrorCode     *int       `bun:"lastErrorCode"`

--- a/apps/proxy/internal/proxy/load_balancer.go
+++ b/apps/proxy/internal/proxy/load_balancer.go
@@ -167,12 +167,15 @@ func (s *Service) getNextAvailableAccount(ctx context.Context, userID, model str
 		account := &prioritized[i]
 		row, ok := health[account.ID]
 		if ok {
+			updatedRow := effectiveHealthStatus(row, now)
+			if updatedRow.Status != row.Status {
+				_, _ = s.db.NewUpdate().Model((*appdb.ProviderAccountModelHealth)(nil)).Set("status = ?", updatedRow.Status).Set("\"statusChangedAt\" = ?", now).Where("id = ?", row.ID).Exec(ctx)
+			}
+			row = updatedRow
 			if row.Status == "failed" {
 				if row.StatusChangedAt != nil && now.Sub(*row.StatusChangedAt) < failedCooldown {
 					continue
 				}
-				reason := "cooldown expired, probing"
-				_, _ = s.db.NewUpdate().Model((*appdb.ProviderAccountModelHealth)(nil)).Set("status = ?", "half_open").Set("\"statusReason\" = ?", reason).Set("\"statusChangedAt\" = ?", now).Where("id = ?", row.ID).Exec(ctx)
 			}
 			if row.Status == "half_open" || row.Status == "degraded" {
 				if selected == nil {
@@ -189,6 +192,14 @@ func (s *Service) getNextAvailableAccount(ctx context.Context, userID, model str
 	}
 	go s.bumpAccountRequestCount(context.Background(), selected.ID, now)
 	return selected, true, nil
+}
+
+func effectiveHealthStatus(row appdb.ProviderAccountModelHealth, now time.Time) appdb.ProviderAccountModelHealth {
+	if row.Status != "failed" || row.StatusChangedAt == nil || now.Sub(*row.StatusChangedAt) < failedCooldown {
+		return row
+	}
+	row.Status = "degraded"
+	return row
 }
 
 func (s *Service) bumpAccountRequestCount(ctx context.Context, accountID string, usedAt time.Time) {
@@ -294,9 +305,17 @@ func (s *Service) markAccountSuccess(ctx context.Context, accountID, model strin
 	if err != nil {
 		return
 	}
-	query := s.db.NewUpdate().Model((*appdb.ProviderAccountModelHealth)(nil)).Set("\"consecutiveErrors\" = 0").Set("\"lastSuccessAt\" = ?", now).Where("id = ?", health.ID)
+	nextErrors := health.ConsecutiveErrors
+	if nextErrors > 0 {
+		nextErrors--
+	}
+	query := s.db.NewUpdate().Model((*appdb.ProviderAccountModelHealth)(nil)).Set("\"consecutiveErrors\" = ?", nextErrors).Set("\"lastSuccessAt\" = ?", now).Where("id = ?", health.ID)
 	if health.Status == "degraded" || health.Status == "failed" || health.Status == "half_open" {
-		query.Set("status = ?", "active").Set("\"statusReason\" = NULL").Set("\"statusChangedAt\" = ?", now)
+		if nextErrors > 0 {
+			query.Set("status = ?", "degraded").Set("\"statusChangedAt\" = ?", now)
+		} else {
+			query.Set("status = ?", "active").Set("\"statusChangedAt\" = ?", now)
+		}
 	}
 	_, _ = query.Exec(ctx)
 }
@@ -329,19 +348,15 @@ func (s *Service) markAccountFailed(ctx context.Context, accountID, model string
 	var health appdb.ProviderAccountModelHealth
 	if err := s.db.NewSelect().Model(&health).Where("\"providerAccountId\" = ?", accountID).Where("model = ?", resolved).Limit(1).Scan(ctx); err == nil {
 		newStatus := ""
-		reason := ""
 		if health.Status == "half_open" {
 			newStatus = "failed"
-			reason = "probe failed during half-open (" + resolved + ")"
 		} else if health.ConsecutiveErrors >= failedThreshold && health.Status != "failed" {
 			newStatus = "failed"
-			reason = "consecutive errors on " + resolved
 		} else if health.ConsecutiveErrors >= degradedThreshold && health.Status == "active" {
 			newStatus = "degraded"
-			reason = "consecutive errors on " + resolved
 		}
 		if newStatus != "" {
-			_, _ = s.db.NewUpdate().Model((*appdb.ProviderAccountModelHealth)(nil)).Set("status = ?", newStatus).Set("\"statusReason\" = ?", reason).Set("\"statusChangedAt\" = ?", now).Where("id = ?", health.ID).Exec(ctx)
+			_, _ = s.db.NewUpdate().Model((*appdb.ProviderAccountModelHealth)(nil)).Set("status = ?", newStatus).Set("\"statusChangedAt\" = ?", now).Where("id = ?", health.ID).Exec(ctx)
 			if newStatus == "failed" {
 				s.disableAccountForFailedCooldown(ctx, accountID, now)
 			}
@@ -374,7 +389,6 @@ func (s *Service) markAccountUsageLimited(ctx context.Context, accountID, model 
 	if isSyntheticProviderAccountID(accountID) {
 		return
 	}
-	reason := "usage limit reached until " + disabledUntil.UTC().Format(time.RFC3339)
 	_, _ = s.db.NewUpdate().Model((*appdb.ProviderAccount)(nil)).
 		Set("\"disabledUntil\" = ?", disabledUntil).
 		Where("id = ?", accountID).
@@ -383,7 +397,6 @@ func (s *Service) markAccountUsageLimited(ctx context.Context, accountID, model 
 	resolved := s.registry.ResolveAlias(model)
 	_, _ = s.db.NewUpdate().Model((*appdb.ProviderAccountModelHealth)(nil)).
 		Set("status = ?", "failed").
-		Set("\"statusReason\" = ?", reason).
 		Set("\"statusChangedAt\" = ?", failedAt).
 		Where("\"providerAccountId\" = ?", accountID).
 		Where("model = ?", resolved).

--- a/apps/proxy/internal/proxy/load_balancer_test.go
+++ b/apps/proxy/internal/proxy/load_balancer_test.go
@@ -1,0 +1,18 @@
+package proxy
+
+import (
+	"testing"
+	"time"
+
+	appdb "github.com/opendum/opendum/apps/proxy/internal/db"
+)
+
+func TestEffectiveHealthStatusDowngradesExpiredFailed(t *testing.T) {
+	now := time.Date(2026, 5, 13, 12, 0, 0, 0, time.UTC)
+	changedAt := now.Add(-failedCooldown)
+	health := effectiveHealthStatus(appdb.ProviderAccountModelHealth{Status: "failed", StatusChangedAt: &changedAt}, now)
+
+	if health.Status != "degraded" {
+		t.Fatalf("expired failed health status = %q, want degraded", health.Status)
+	}
+}


### PR DESCRIPTION
## Summary
- Simplify account/model health status by removing statusReason from schema and API models.
- Downgrade expired failed health to degraded and decrement degraded error count on successful requests.
- Show health badges as icon plus consecutive error count only.

## Verification
- go test ./...
- go build ./...