### PR TITLE
feat: add Qoder provider (API key / PAT)

### DIFF
--- a/apps/dashboard/app/components/AddAccountDialog.vue
+++ b/apps/dashboard/app/components/AddAccountDialog.vue
@@ -64,6 +64,7 @@ const providerConfigs: Record<Provider, ProviderConfig> = {
   nvidia_nim: { name: "Nvidia", description: "Access NIM models with direct API key", methods: [apiKeyMethod], apiKeyPortalUrl: "https://build.nvidia.com/settings/api-keys", apiKeyPlaceholder: "nvapi-..." },
   openrouter: { name: "Openrouter", description: "Access Openrouter free models via API key", methods: [apiKeyMethod], apiKeyPortalUrl: "https://openrouter.ai/settings/keys", apiKeyPlaceholder: "sk-or-v1-..." },
   workers_ai: { name: "Workers AI", description: "Access open-source models on Cloudflare's global network", methods: [apiTokenWithAccountIdMethod], apiKeyPortalUrl: "https://dash.cloudflare.com/?to=/:account/ai/workers-ai", apiKeyPlaceholder: "Bearer token...", accountIdPlaceholder: "e.g. 1a2b3c4d5e6f...", accountIdLabel: "Cloudflare Account ID" },
+  qoder: { name: "Qoder", description: "Access Qoder models via PAT", methods: [apiKeyMethod], apiKeyPortalUrl: "https://qoder.com/account/integrations", apiKeyPlaceholder: "qod_pat_..." },
 };
 
 const chatgptSessionPlaceholder = `{
@@ -81,7 +82,7 @@ const chatgptSessionPlaceholder = `{
   "sessionToken": "eyJ..."
 }`;
 
-const providerOptions: Provider[] = ["antigravity", "codex", "kiro", "gemini_cli", "qwen_code", "copilot", "openrouter", "nvidia_nim", "workers_ai"];
+const providerOptions: Provider[] = ["antigravity", "codex", "kiro", "gemini_cli", "qwen_code", "copilot", "openrouter", "nvidia_nim", "workers_ai", "qoder"];
 
 const open = ref(false);
 const minimumStep = computed(() => (props.initialProvider ? 2 : 1));

--- a/apps/dashboard/lib/provider-accounts.ts
+++ b/apps/dashboard/lib/provider-accounts.ts
@@ -6,6 +6,7 @@ export type ProviderAccountKey =
   | "kiro"
   | "nvidia_nim"
   | "openrouter"
+  | "qoder"
   | "qwen_code"
   | "workers_ai";
 
@@ -91,6 +92,14 @@ export const PROVIDER_ACCOUNT_DEFINITIONS: ProviderAccountDefinition[] = [
     label: "Workers AI",
     category: "api_key",
     emptyMessage: "No Workers AI accounts connected yet.",
+    showTier: false,
+  },
+  {
+    key: "qoder",
+    slug: "qoder",
+    label: "Qoder",
+    category: "api_key",
+    emptyMessage: "No Qoder connections yet.",
     showTier: false,
   },
 ];

--- a/apps/dashboard/server/services/account-connectors.ts
+++ b/apps/dashboard/server/services/account-connectors.ts
@@ -16,7 +16,7 @@ const API_KEY_PROVIDER_ACCOUNT_EXPIRY = new Date("2100-01-01T00:00:00.000Z");
 const API_KEY_VALIDATION_TIMEOUT_MS = 15000;
 const INTERNAL_RELAY_ERROR_HEADER = "X-Opendum-Internal-Relay-Error";
 
-const apiKeyProviderSchema = z.enum(["nvidia_nim", "openrouter"]);
+const apiKeyProviderSchema = z.enum(["nvidia_nim", "openrouter", "qoder"]);
 export const createAccountInputSchema = z.object({ provider: z.string(), name: z.string().optional(), token: z.string(), cfAccountId: z.string().optional() });
 type ApiKeyProvider = z.infer<typeof apiKeyProviderSchema>;
 type CreateAccountInput = z.infer<typeof createAccountInputSchema>;
@@ -24,6 +24,7 @@ type CreateAccountInput = z.infer<typeof createAccountInputSchema>;
 const API_KEY_PROVIDER_SETTINGS = {
   nvidia_nim: { label: "Nvidia", baseUrl: nvidiaApiBaseUrl, modelMap: getProviderModelMap("nvidia_nim"), validationPath: "/chat/completions", requireSuccessfulStatus: false },
   openrouter: { label: "Openrouter", baseUrl: openRouterApiBaseUrl, modelMap: getProviderModelMap("openrouter"), validationPath: "/models", requireSuccessfulStatus: true },
+  qoder: { label: "Qoder", baseUrl: "https://openapi.qoder.sh/api/v1", modelMap: getProviderModelMap("qoder"), validationPath: "/models", requireSuccessfulStatus: true },
 } satisfies Record<ApiKeyProvider, { label: string; baseUrl: string; modelMap: Record<string, string>; validationPath: "/models" | "/chat/completions"; requireSuccessfulStatus: boolean }>;
 
 function buildValidationRequest(provider: ApiKeyProvider, apiKey: string) {

--- a/apps/dashboard/server/services/account-providers.ts
+++ b/apps/dashboard/server/services/account-providers.ts
@@ -7,6 +7,7 @@ export const PROVIDER_ACCOUNT_KEYS = [
   "qwen_code",
   "nvidia_nim",
   "openrouter",
+  "qoder",
   "workers_ai",
 ] as const;
 

--- a/apps/proxy/internal/providers/providers.go
+++ b/apps/proxy/internal/providers/providers.go
@@ -70,6 +70,7 @@ func NewRegistry(registry *models.Registry, db *appdb.DB, redis *redis.Client) *
 		"copilot":      copilotProvider{registry: registry, redis: redis},
 		"gemini_cli":   geminiCLIProvider{registry: registry, db: db, redis: redis},
 		"antigravity":  antigravityProvider{registry: registry, db: db, redis: redis},
+		"qoder":        openAICompatibleProvider{name: "qoder", baseURL: "https://openapi.qoder.sh/api/v1", supportedParams: supportedQoder, registry: registry, trimPrefix: "qoder/"},
 	}}
 }
 
@@ -503,6 +504,8 @@ func set(values ...string) map[string]struct{} {
 	}
 	return out
 }
+
+var supportedQoder = set("model", "messages", "temperature", "top_p", "max_tokens", "max_completion_tokens", "stream", "stream_options", "tools", "tool_choice", "presence_penalty", "frequency_penalty", "n", "stop", "seed", "response_format", "reasoning", "reasoning_effort")
 
 var supportedOpenRouter = set("model", "messages", "temperature", "top_p", "max_tokens", "max_completion_tokens", "stream", "stream_options", "tools", "tool_choice", "presence_penalty", "frequency_penalty", "n", "stop", "seed", "response_format", "reasoning", "reasoning_effort")
 

--- a/models/qwen/qwen3.7-max.json
+++ b/models/qwen/qwen3.7-max.json
@@ -1,0 +1,11 @@
+{
+  "providers": [
+    "qoder"
+  ],
+  "family": "Qwen",
+  "meta": {
+    "reasoning": true,
+    "toolCall": true,
+    "vision": true
+  }
+}


### PR DESCRIPTION

Adds Qoder as a new API key provider in opendum.

**Changes:**
- **Go proxy**: Register `qoder` as `openAICompatibleProvider` with base URL `https://openapi.qoder.sh/api/v1`, PAT auth via `Authorization: Bearer <token>`
- **Dashboard**: Add `qoder` to provider keys, definitions, connector settings, and account dialog
- **Model**: Add `qoder` provider entry to `models/qwen/qwen3.7-max.json` (free tier model)

**Provider config:**
- Auth: Personal Access Token (PAT) — generated at https://qoder.com/account/integrations
- API: OpenAI-compatible chat completions
